### PR TITLE
(fix): cross-check with markdown file extension

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,7 @@ export class Build {
       nodir: true,
       absolute: false,
       ignore: options.exclude || [],
-    })).filter(filepath => !filepath.endsWith('.d.ts') && !filepath.includes('README'));
+    })).filter(filepath => !filepath.endsWith('.d.ts') && !filepath.endsWith('.md'));
 
     for (const sourcePath of files) {
       const sourcePathAbs = path.join(dir, sourcePath);


### PR DESCRIPTION
Changes made:

Replacing the check for *readme* files with `!filepath.endsWith('.md')`. Currently the check is happening with `!filepath.includes('README')` where the files that are named using **Readme.md** are escaping. 

I feel with this new check we can eliminate any other files that ends with **.md** as well.

Currently i observed the behaviour here -> https://github.com/JayaKrishnaNamburu/design-system/tree/master/src/Select